### PR TITLE
Informer OnClose Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Fix #2981: Add DSL support for `storage.k8s.io/v1beta1` CSIDriver, CSINode and VolumeAttachment
 * Fix #2912: Add DSL support for `storage.k8s.io/v1beta1` CSIStorageCapacity
 * Fix #2701: Better support for patching in KuberntesClient
+* Fix #3034: Added a SharedInformer.isRunning method
 
 #### _**Note**_: Breaking changes in the API
 ##### DSL Changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fix #3011: properly handle enum types for additional printer columns
 * Fix #3020: annotations should now properly have their associated values when processing CRDs from the API
 * Fix #3027: fix NPE when sorting events in KubernetesResourceUtil
+* Fix #3024: stopAllRegisteredInformers will not call startWatcher
 
 #### Improvements
 * Fix #2788: Support FIPS mode in kubernetes-client with BouncyCastleFipsProvider

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformer.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformer.java
@@ -59,4 +59,9 @@ public interface SharedInformer<T> {
    * @return string value
    */
   String lastSyncResourceVersion();
+  
+  /**
+   * Return true if the informer is running
+   */
+  boolean isRunning();
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
@@ -24,8 +24,6 @@ import io.fabric8.kubernetes.client.informers.ListerWatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -39,28 +37,18 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
   private final ListerWatcher<T, L> listerWatcher;
   private final Store<T> store;
   private final OperationContext operationContext;
-  private final long resyncPeriodMillis;
-  private final ScheduledExecutorService resyncExecutor;
   private final ReflectorWatcher<T> watcher;
   private final AtomicBoolean isActive;
-  private final AtomicBoolean isWatcherStarted;
   private final AtomicReference<Watch> watch;
 
-  public Reflector(Class<T> apiTypeClass, ListerWatcher<T, L> listerWatcher, Store store, OperationContext operationContext, long resyncPeriodMillis) {
-    this(apiTypeClass, listerWatcher, store, operationContext, resyncPeriodMillis, Executors.newSingleThreadScheduledExecutor());
-  }
-
-  public Reflector(Class<T> apiTypeClass, ListerWatcher<T, L> listerWatcher, Store store, OperationContext operationContext, long resyncPeriodMillis, ScheduledExecutorService resyncExecutor) {
+  public Reflector(Class<T> apiTypeClass, ListerWatcher<T, L> listerWatcher, Store store, OperationContext operationContext) {
     this.apiTypeClass = apiTypeClass;
     this.listerWatcher = listerWatcher;
     this.store = store;
     this.operationContext = operationContext;
-    this.resyncPeriodMillis = resyncPeriodMillis;
     this.lastSyncResourceVersion = new AtomicReference<>();
-    this.resyncExecutor = resyncExecutor;
     this.watcher = new ReflectorWatcher<>(store, lastSyncResourceVersion, this::startWatcher, this::reListAndSync);
     this.isActive = new AtomicBoolean(true);
-    this.isWatcherStarted = new AtomicBoolean(false);
     this.watch = new AtomicReference<>(null);
   }
 
@@ -79,14 +67,10 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
 
   public void stop() {
     isActive.set(false);
-    if (watch.get() != null) {
-      watch.get().close();
-      watch.set(null);
+    Watch theWatch = watch.getAndSet(null);
+    if (theWatch != null) {
+      theWatch.close();
     }
-  }
-
-  public long getResyncPeriodMillis() {
-    return resyncPeriodMillis;
   }
 
   private void reListAndSync() {
@@ -96,19 +80,14 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
     log.debug("Listing items ({}) for resource {} v{}", list.getItems().size(), apiTypeClass, latestResourceVersion);
     lastSyncResourceVersion.set(latestResourceVersion);
     store.replace(list.getItems(), latestResourceVersion);
-    if (!isActive.get()) {
-      resyncExecutor.shutdown();
-    }
   }
 
   private void startWatcher() {
     log.debug("Starting watcher for resource {} v{}", apiTypeClass, lastSyncResourceVersion.get());
-    if (watch.get() != null) {
-      log.debug("Stopping previous watcher");
-      watch.get().close();
-    }
-    if (isWatcherStarted.get()) {
-      log.debug("Watcher already started, delaying execution of new watcher");
+    Watch theWatch = watch.getAndSet(null);
+    if (theWatch != null) {
+      theWatch.close();
+      log.debug("Stopping previous watcher, and delaying execution of new watcher");
       try {
         Thread.sleep(WATCH_RESTART_DELAY_MILLIS);
       } catch (InterruptedException e) {
@@ -118,7 +97,6 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
       }
     }
     if (isActive.get()) {
-      isWatcherStarted.set(true);
       watch.set(
         listerWatcher.watch(new ListOptionsBuilder()
           .withWatch(Boolean.TRUE).withResourceVersion(lastSyncResourceVersion.get()).withTimeoutSeconds(null).build(),
@@ -129,5 +107,9 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
 
   public String getLastSyncResourceVersion() {
     return lastSyncResourceVersion.get();
+  }
+  
+  public boolean isRunning() {
+    return isActive.get();
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.client.WatcherException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
@@ -70,10 +69,12 @@ public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
 
   @Override
   public void onClose(WatcherException exception) {
+    // this close was triggered by an exception,
+    // not the user, it is expected that the watch retry will handle this
     log.warn("Watch closing with exception", exception);
-    Optional.ofNullable(exception)
-      .filter(WatcherException::isHttpGone)
-      .ifPresent(c -> onHttpGone.run());
+    if (exception.isHttpGone()) {
+        onHttpGone.run();
+    }
     onClose.run();
   }
 
@@ -87,4 +88,5 @@ public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
   public boolean reconnecting() {
     return true;
   }
+  
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
@@ -30,13 +30,11 @@ public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
 
   private final Store<T> store;
   private final AtomicReference<String> lastSyncResourceVersion;
-  private final Runnable onClose;
   private final Runnable onHttpGone;
 
-  public ReflectorWatcher(Store<T> store, AtomicReference<String> lastSyncResourceVersion, Runnable onClose, Runnable onHttpGone) {
+  public ReflectorWatcher(Store<T> store, AtomicReference<String> lastSyncResourceVersion, Runnable onHttpGone) {
     this.store = store;
     this.lastSyncResourceVersion = lastSyncResourceVersion;
-    this.onClose = onClose;
     this.onHttpGone = onHttpGone;
   }
 
@@ -75,13 +73,11 @@ public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
     if (exception.isHttpGone()) {
         onHttpGone.run();
     }
-    onClose.run();
   }
 
   @Override
   public void onClose() {
     log.debug("Watch gracefully closed");
-    onClose.run();
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformer.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformer.java
@@ -230,4 +230,9 @@ public class DefaultSharedIndexInformer<T extends HasMetadata, L extends Kuberne
     }
     return desired < check ? check : desired;
   }
+
+  @Override
+  public boolean isRunning() {
+    return !stopped && started && controller.isRunning(); 
+  }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ControllerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ControllerTest.java
@@ -55,7 +55,7 @@ class ControllerTest {
       1000L, operationContext, eventListeners);
 
     // Then
-    assertEquals(1000L, controller.getReflector().getResyncPeriodMillis());
+    assertEquals(1000L, controller.getFullResyncPeriod());
   }
 
   @Test
@@ -77,7 +77,7 @@ class ControllerTest {
       0L, operationContext, eventListeners);
 
     // Then
-    assertEquals(0L, controller.getReflector().getResyncPeriodMillis());
+    assertEquals(0L, controller.getFullResyncPeriod());
   }
 
   @Test
@@ -92,7 +92,6 @@ class ControllerTest {
     // When
     controller.stop();
     // Then
-    assertThat(controller.getReflectExecutor().isShutdown()).isTrue();
     assertThat(controller.getResyncExecutor().isShutdown()).isTrue();
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
@@ -67,6 +67,7 @@ import java.util.function.Function;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableKubernetesMockClient
 class DefaultSharedIndexInformerTest {
@@ -835,8 +836,14 @@ class DefaultSharedIndexInformerTest {
     factory.startAllRegisteredInformers();
     updates.await(LATCH_AWAIT_PERIOD_IN_SECONDS, TimeUnit.SECONDS);
 
+    // should still be running after all that
+    assertTrue(podInformer.isRunning());
     // Then
     assertEquals(0, updates.getCount());
+
+    podInformer.stop();
+
+    assertFalse(podInformer.isRunning());
   }
 
   private KubernetesResource getAnimal(String name, String order, String resourceVersion) {


### PR DESCRIPTION
## Description
further cleanups to the Informer onClose behavior

this incorporates the Reflector changes from fabric8io#3029

It goes further in refining responsibilities by mostly relying on the watch for tracking the lastResourceVersion and removing onClose behavior that is no longer necessary due to fabric8io#3018

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
