### PR TITLE
fix #3144: making the crud mock logic more crd aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 
 #### Improvements
+* Fix #3135 added mock crud support for patch status, and will return exceptions for unsupported patch types
 
 #### Dependency Upgrade
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 5.5-SNAPSHOT
 
 #### Bugs
+* Fix #3144 walking back the assumption that /status should be a subresource, now it will be only if a registered crd indicates that it should be
 
 #### Improvements
 * Fix #3135 added mock crud support for patch status, and will return exceptions for unsupported patch types

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContext.java
@@ -34,6 +34,7 @@ public class CustomResourceDefinitionContext {
   private String plural;
   private String version;
   private String kind;
+  private boolean statusSubresource;
 
   public String getName() { return name; }
 
@@ -55,6 +56,10 @@ public class CustomResourceDefinitionContext {
 
   public String getKind() {
     return kind;
+  }
+  
+  public boolean isStatusSubresource() {
+    return statusSubresource;
   }
 
   @SuppressWarnings("rawtypes")
@@ -136,19 +141,26 @@ public class CustomResourceDefinitionContext {
       .withName(crd.getMetadata().getName())
       .withPlural(spec.getNames().getPlural())
       .withKind(spec.getNames().getKind())
+      .withStatusSubresource(spec.getSubresources() != null && spec.getSubresources().getStatus() != null)
       .build();
   }
 
   public static CustomResourceDefinitionContext fromCrd(
     io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition crd
   ) {
+    String version = getVersion(crd.getSpec());
     return new CustomResourceDefinitionContext.Builder()
       .withGroup(crd.getSpec().getGroup())
-      .withVersion(getVersion(crd.getSpec()))
+      .withVersion(version)
       .withScope(crd.getSpec().getScope())
       .withName(crd.getMetadata().getName())
       .withPlural(crd.getSpec().getNames().getPlural())
       .withKind(crd.getSpec().getNames().getKind())
+      .withStatusSubresource(crd.getSpec()
+          .getVersions()
+          .stream()
+          .filter(v -> version.equals(v.getName()))
+          .anyMatch(v -> v.getSubresources() != null && v.getSubresources().getStatus() != null))
       .build();
   }
 
@@ -212,6 +224,11 @@ public class CustomResourceDefinitionContext {
 
     public Builder withKind(String kind) {
       this.customResourceDefinitionContext.kind = kind;
+      return this;
+    }
+    
+    public Builder withStatusSubresource(boolean statusSubresource) {
+      this.customResourceDefinitionContext.statusSubresource = statusSubresource;
       return this;
     }
 

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/CustomResourceDefinitionProcessor.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/CustomResourceDefinitionProcessor.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.client.server.mock;
+
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import io.fabric8.kubernetes.client.utils.Serialization;
+
+import java.util.Optional;
+
+/**
+ * Holds state related to crds by manipulating the crds known to the attributes extractor
+ */
+public class CustomResourceDefinitionProcessor {
+
+  private static final String V1BETA1_PATH = "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions";
+  private static final String V1_PATH = "/apis/apiextensions.k8s.io/v1/customresourcedefinitions";
+
+  private KubernetesAttributesExtractor extractor;
+
+  public CustomResourceDefinitionProcessor(KubernetesAttributesExtractor extractor) {
+    this.extractor = extractor;
+  }
+
+  public void process(String path, String crdString, boolean delete) {
+    CustomResourceDefinitionContext context = null;
+    if (path.startsWith(V1BETA1_PATH)) {
+      io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition crd = Serialization
+          .unmarshal(crdString, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition.class);
+      context = CustomResourceDefinitionContext.fromCrd(crd);
+    } else if (path.startsWith(V1_PATH)) {
+      CustomResourceDefinition crd = Serialization.unmarshal(crdString, CustomResourceDefinition.class);
+      context = CustomResourceDefinitionContext.fromCrd(crd);
+    } else {
+      return;
+    }
+    if (delete) {
+      extractor.getCrdContexts().remove(context.getPlural());
+    } else {
+      extractor.getCrdContexts().put(context.getPlural(), context);
+    }
+  }
+
+  public boolean isStatusSubresource(String kind) {
+    if (kind == null) {
+      return false;
+    }
+    // we are only holding by plural, lookup now by kind
+    Optional<CustomResourceDefinitionContext> context =
+        extractor.getCrdContexts().values().stream().filter(c -> kind.equalsIgnoreCase(c.getKind())).findFirst();
+    if (!context.isPresent()) {
+      return false;
+    }
+    return context.get().isStatusSubresource();
+  }
+
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
@@ -20,23 +20,28 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.dsl.internal.RawCustomResourceOperationsImpl;
 import io.fabric8.kubernetes.client.mock.crd.CronTab;
 import io.fabric8.kubernetes.client.mock.crd.CronTabSpec;
+import io.fabric8.kubernetes.client.mock.crd.CronTabStatus;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.internal.KubernetesDeserializer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableKubernetesMockClient(crud = true)
@@ -145,6 +150,54 @@ class CustomResourceCrudTest {
     cronTabClient.inNamespace("test-ns").withName("my-third-cron-object").delete();
     cronTabList = cronTabClient.inNamespace("test-ns").list();
     assertEquals(2, cronTabList.getItems().size());
+  }
+
+  @Test
+  void testStatusSubresourceHandling() {
+    CronTab cronTab = createCronTab("my-new-cron-object", "* * * * */5", 3, "my-awesome-cron-image");
+    CronTabStatus status = new CronTabStatus();
+    status.setReplicas(1);
+    cronTab.setStatus(status);
+
+    NonNamespaceOperation<CronTab, KubernetesResourceList<CronTab>, Resource<CronTab>> cronTabClient = client
+        .customResources(CronTab.class).inNamespace("test-ns");
+
+    CronTab result = cronTabClient.create(cronTab);
+
+    // should be null after create
+    assertNull(result.getStatus());
+
+    Map<String, String> labels = new HashMap<>();
+    labels.put("app", "core");
+
+    cronTab.getMetadata().setLabels(labels);
+
+    result = cronTabClient.replace(cronTab);
+
+    String originalUid = result.getMetadata().getUid();
+
+    // should be null after replace
+    assertNull(result.getStatus());
+
+    assertNotNull(cronTabClient.updateStatus(cronTab).getStatus());
+
+    labels.put("other", "label");
+    cronTab.setStatus(null);
+
+    result = cronTabClient.replace(cronTab);
+
+    // should retain the existing
+    assertNotNull(result.getStatus());
+
+    labels.put("another", "label");
+    result = cronTabClient.patch(cronTab);
+
+    // should retain the existing
+    assertNotNull(result.getStatus());
+    // should have accumulated all labels
+    assertEquals(new HashSet<String>(Arrays.asList("app", "other", "another")), result.getMetadata().getLabels().keySet());
+
+    assertEquals(originalUid, result.getMetadata().getUid());
   }
 
   void assertCronTab(CronTab cronTab, String name, String cronTabSpec, int replicas, String image) {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodCrudTest.java
@@ -105,7 +105,7 @@ class PodCrudTest {
     Watch watch = client.pods().inNamespace("ns1").withName(pod1.getMetadata().getName()).watch(lw);
 
     pod1 = client.pods().inNamespace("ns1").withName(pod1.getMetadata().getName())
-      .patch(new PodBuilder().withNewMetadataLike(pod1.getMetadata()).endMetadata().build());
+      .edit(p->new PodBuilder(p).editMetadata().withLabels(Collections.singletonMap("x", "y")).endMetadata().build());
 
     pod1.setSpec(new PodSpecBuilder().addNewContainer().withImage("nginx").withName("nginx").endContainer().build());
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TypedClusterScopeCustomResourceApiTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TypedClusterScopeCustomResourceApiTest.java
@@ -22,14 +22,12 @@ import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.mock.crd.Star;
 import io.fabric8.kubernetes.client.mock.crd.StarSpec;
 import io.fabric8.kubernetes.client.mock.crd.StarStatus;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
@@ -41,18 +39,11 @@ import static org.junit.Assert.assertTrue;
 
 @EnableKubernetesMockClient
 class TypedClusterScopeCustomResourceApiTest {
-  
+
     KubernetesMockServer server;
     KubernetesClient client;
 
     private MixedOperation<Star, KubernetesResourceList<Star>, Resource<Star>> starClient;
-    
-    private CustomResourceDefinitionContext crdContext;
-
-    @BeforeEach
-    void setupCrd() {
-      crdContext = CustomResourceDefinitionContext.fromCustomResourceType(Star.class);
-    }
 
     @Test
     void create() {

--- a/kubernetes-tests/src/test/resources/crontab-crd.yml
+++ b/kubernetes-tests/src/test/resources/crontab-crd.yml
@@ -64,3 +64,6 @@ spec:
     kind: CronTab
     shortNames:
       - ct
+  subresources:
+    status: {}
+


### PR DESCRIPTION
## Description
#3144 this builds upon the #3138 to add broader crd awareness to the mock server - primarily for determining if status is a subresource

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
